### PR TITLE
Add Galaxy Info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,19 @@
+---
+
+galaxy_info:
+  author: 'Ryo Tagami'
+  description: 'MidoNet Manager'
+  company: 'Midokura'
+  min_ansible_version: '2.2'
+  license: 'Apache'
+  platforms:
+    - name: 'EL'
+      versions:
+        - '7'
+    - name: 'Ubuntu'
+      versions:
+        - 'trusty'
+        - 'xenial'
+  categories:
+    - 'cloud'
+    - 'networking'


### PR DESCRIPTION
Add `meta/main.yml` to be able to use `ansible-galaxy` command to
install this role.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>