### PR TITLE
Disable Truthy Checks

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -5,3 +5,4 @@ extends: default
 rules:
   line-length:
     max: 160
+  truthy: disable

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,4 @@
 ---
 
-- src: https://github.com/midonet/ansible-midonet-repo
+- name: 'midonet-repo'
+  src: 'https://github.com/midonet/ansible-midonet-repo'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,10 +3,10 @@
 - hosts: all
   become: True
   roles:
-    - role: ansible-midonet-repo
+    - role: midonet-repo
       midonet_version: '5.2'
       mem_username: 'calsoft'
       mem_password: 'dummypwd'
 
-    - role: midonet-manager
+    - role: ansible-midonet-manager
       ssl_enabled: False


### PR DESCRIPTION
YAMLLint have introduced truthy checks in the following commit
(https://github.com/adrienverge/yamllint/commit/1f472bc)
, however we are not going to stick to this rule for now, since we
already uniformed our booleans to `True` or `False`.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>